### PR TITLE
Add dealer selection option

### DIFF
--- a/testing.py
+++ b/testing.py
@@ -247,7 +247,8 @@ class WizardGameSimulator:
             current_trick_cards=current_trick_cards_on_table,
             played_cards=played_cards_globally,
             current_player=current_player_for_state,
-            trick_leader=trick_leader
+            trick_leader=trick_leader,
+            dealer=(round_number - 1) % self.num_players
         )
 
 

--- a/wizard_assistant.py
+++ b/wizard_assistant.py
@@ -721,7 +721,7 @@ class WizardGameSimulator:
         
         # Initialisiere Stiche
         tricks_won = {player: 0 for player in players}
-        
+
         return GameState(
             round_number=round_number,
             current_trick=current_trick,
@@ -733,7 +733,8 @@ class WizardGameSimulator:
             current_trick_cards=[],
             played_cards=set(),
             current_player=players[0],
-            trick_leader=players[0]
+            trick_leader=players[0],
+            dealer=(round_number - 1) % len(players)
         )
     
     def simulate_complete_game(self) -> Dict[int, int]:
@@ -1001,7 +1002,8 @@ def create_example_game_state() -> GameState:
         current_trick_cards=[],
         played_cards=played_cards,
         current_player=0,
-        trick_leader=0
+        trick_leader=0,
+        dealer=0
     )
 
 def main():

--- a/wizard_core_game_classes.py
+++ b/wizard_core_game_classes.py
@@ -100,6 +100,7 @@ class GameState:
     - played_cards: Set aller Karten, die in dieser Runde bereits gespielt wurden
     - current_player: welcher Spieler ist gerade am Zug
     - trick_leader: wer hat den letzten Stich gewonnen (führt nächsten an)
+    - dealer: welcher Spieler teilt die Karten dieser Runde aus
     """
     round_number: int
     current_trick: int
@@ -112,6 +113,7 @@ class GameState:
     played_cards: Set[Card]
     current_player: int
     trick_leader: int
+    dealer: int
     last_wizard_wins: bool = False
     
     def copy(self):

--- a/wizard_game_manager.py
+++ b/wizard_game_manager.py
@@ -22,7 +22,7 @@ class WizardGameManager:
         self.confirm_play: bool = False
         self.last_wizard_wins: bool = False
 
-    def start_new_game(self, num_players: int, player_types: Dict[int, str], human_player_id: int, start_round: int = 1, deal_digitally: bool = True, confirm_play: bool = False,last_wizard_wins: bool = False):
+    def start_new_game(self, num_players: int, player_types: Dict[int, str], human_player_id: int, start_round: int = 1, deal_digitally: bool = True, confirm_play: bool = False,last_wizard_wins: bool = False, dealer: Optional[int] = None):
         """Initialisiert ein komplett neues Spiel."""
         self.player_types = player_types
         self.human_player_id = human_player_id
@@ -30,7 +30,7 @@ class WizardGameManager:
         self.confirm_play = confirm_play
         self.last_wizard_wins = last_wizard_wins
         self.total_scores = {p: 0 for p in range(num_players)}
-        self.start_new_round(round_number=start_round, num_players=num_players)
+        self.start_new_round(round_number=start_round, num_players=num_players, dealer=dealer)
 
     def is_human_hand_set(self):
         """Check if the human player's hand has been set (for manual card input)."""
@@ -52,11 +52,12 @@ class WizardGameManager:
             self.game_state.hands[player_id] = hand_cards
 
 
-    def start_new_round(self, round_number: int, num_players: int):
+    def start_new_round(self, round_number: int, num_players: int, dealer: Optional[int] = None):
         """Bereitet den Spielzustand für eine neue Runde vor."""
         self.last_trick = None
         players = list(range(num_players))
-        dealer = (round_number - 1) % num_players
+        if dealer is None:
+            dealer = (round_number - 1) % num_players
         start_player = (dealer + 1) % num_players
 
         deck = WizardDeck()
@@ -78,6 +79,7 @@ class WizardGameManager:
             players=players, hands=hands, bids={}, tricks_won={p: 0 for p in players},
             current_trick_cards=[], played_cards=set(),
             current_player=start_player, trick_leader=start_player,
+            dealer=dealer,
             last_wizard_wins=self.last_wizard_wins  # NEUES ARGUMENT
         )
         self.current_round_scores = {p: 0 for p in players}
@@ -183,4 +185,5 @@ class WizardGameManager:
             next_round_number = self.game_state.round_number + 1
             max_rounds = 60 // num_players
             if next_round_number <= max_rounds:
-                self.start_new_round(next_round_number, num_players)
+                new_dealer = (self.game_state.dealer + 1) % num_players
+                self.start_new_round(next_round_number, num_players, dealer=new_dealer)

--- a/wizard_gui.py
+++ b/wizard_gui.py
@@ -188,6 +188,12 @@ class WizardGUI:
             player_types = {i: st.selectbox(f"Typ {st.session_state.player_names[i]}", ["human", "computer"], key=f"player_type_{i}") for i in range(num_players)}
             human_players = [i for i, t in player_types.items() if t == "human"]
             human_player_id = st.selectbox("Hauptspieler (Sie)", human_players, format_func=lambda x: self.get_player_name(x)) if human_players else 0
+            dealer_id = st.selectbox(
+                "Kartengeber (Runde 1)",
+                list(range(num_players)),
+                format_func=lambda x: self.get_player_name(x),
+                key="dealer_select"
+            )
 
         if st.button("Spiel erstellen", disabled=not is_valid_round):
             self.save_state_for_undo()
@@ -199,7 +205,8 @@ class WizardGUI:
                 round_number, 
                 deal_digitally, 
                 confirm_play,
-                last_wizard_wins # Neuer Parameter wird übergeben
+                last_wizard_wins,
+                dealer_id
             )
             # +++ ENDE AKTUALISIERUNG +++
             st.rerun()            


### PR DESCRIPTION
## Summary
- extend `GameState` with `dealer`
- allow specifying dealer when starting new game/round
- rotate dealer between rounds
- show dealer select box on start page

## Testing
- `python3 testing.py` *(fails: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_686c200f67f08323b6dabe413ca93de6